### PR TITLE
only first 32 bytes of HMAC-SHA512 should be used for public/private ckd

### DIFF
--- a/bitcointx/core/key.py
+++ b/bitcointx/core/key.py
@@ -867,7 +867,7 @@ class CExtKeyBase(CExtKeyCommonBase):
         child_privkey = ctypes.create_string_buffer(self.priv.secret_bytes, size=32)
 
         result = _secp256k1.secp256k1_ec_privkey_tweak_add(
-            secp256k1_context_sign, child_privkey, bip32_hash)
+            secp256k1_context_sign, child_privkey, bip32_hash[:32])
 
         if result != 1:
             assert result == 0
@@ -940,7 +940,7 @@ class CExtPubKeyBase(CExtKeyCommonBase):
         raw_pub = self.pub._to_ctypes_char_array()
 
         result = _secp256k1.secp256k1_ec_pubkey_tweak_add(
-            secp256k1_context_verify, raw_pub, bip32_hash)
+            secp256k1_context_verify, raw_pub, bip32_hash[:32])
 
         if result != 1:
             assert result == 0


### PR DESCRIPTION
Working well even without this patch. But I would say it is kind of side effect that happens in secp lib where it probably just use first 32bytes of bip32_hash (which has 64 bytes). With this patch it is explicit that we only use first 32 bytes. 

from BIP32:
  private: The returned child key ki is parse256(IL) + kpar (mod n).
  public: The returned child key Ki is point(parse256(IL)) + Kpar.

In both cases only first 32 bytes (IL) from HMAC-SHA512 is used